### PR TITLE
Fix JSON serialization for service creation

### DIFF
--- a/lib/orchestration_adapter.rb
+++ b/lib/orchestration_adapter.rb
@@ -11,7 +11,7 @@ module OrchestrationAdapter
     end
 
     def create_services(services)
-      response = connection.post services_path, services
+      response = connection.post services_path, services.to_json
       response.body
     end
 

--- a/spec/lib/orchestration_adapter_spec.rb
+++ b/spec/lib/orchestration_adapter_spec.rb
@@ -53,7 +53,7 @@ describe OrchestrationAdapter::Client do
     end
 
     it 'POSTs to /services' do
-      expect(connection).to receive(:post).with('services', services)
+      expect(connection).to receive(:post).with('services', services.to_json)
       subject.create_services(services)
     end
 


### PR DESCRIPTION
Ensure that the service list is serialized to JSON before the services are sent to the adapter for creation.

I was thinking that the `json` middleware for Faraday would handle this automatically, but it doesn't work with complex objects -- it invokes `::JSON.dump` instead of simply calling `.to_json` on the object.
