### PR TITLE
Translate keys for service links

### DIFF
--- a/app/serializers/image_serializer.rb
+++ b/app/serializers/image_serializer.rb
@@ -4,6 +4,15 @@ class ImageSerializer < ActiveModel::Serializer
   attributes :name, :source, :categories, :command, :environment, :links,
     :expose, :ports, :volumes, :volumesFrom, :deployment
 
+  def links
+    object.links.map do |link|
+      {}.tap do |h|
+        h[:name] = link['service']
+        h[:alias] = link['alias']
+      end
+    end
+  end
+
   def ports
     object.ports.map do |port|
       {}.tap do |h|

--- a/spec/serializers/image_serializer_spec.rb
+++ b/spec/serializers/image_serializer_spec.rb
@@ -4,6 +4,9 @@ describe ImageSerializer do
 
   let(:image) do
     Image.new(
+      'links' => [
+        { 'service' => 'a', 'alias' => 'b' }
+      ],
       'ports' => [
         { 'container_port' => 1111, 'host_port' => 2222, 'proto' => 'UDP' }
       ],
@@ -38,6 +41,16 @@ describe ImageSerializer do
       )
 
       expect(serialized.keys).to match_array expected_keys
+    end
+
+    it 're-maps the keys for any links' do
+      serialized = subject.as_json
+
+      expect(serialized[:links].count).to eq 1
+      link = serialized[:links].first
+
+      expect(link[:name]).to eq image.links.first['service']
+      expect(link[:alias]).to eq image.links.first['alias']
     end
 
     it 're-maps the keys for any ports' do


### PR DESCRIPTION
Our template uses `{ service: 'a', alias: 'b' }` for links but the adapter is expecting `{ name: 'a', alias: 'b' }`. Adding some logic in the serializer to translate between the conventions.
